### PR TITLE
fix: 调整步长比率计算以减小随机波动

### DIFF
--- a/main.py
+++ b/main.py
@@ -205,7 +205,7 @@ class MiMotion():
                 hour = find.group(1)
                 min_ratio = max(math.ceil((int(hour) / 3) - 1), 0)
                 max_ratio = math.ceil(int(hour) / 3)
-                step_ratio = random.uniform(min_ratio, max_ratio)
+                step_ratio = random.uniform(min_ratio, max_ratio)*0.1
                 min_1 = 3500 * min_ratio
                 max_1 = 3500 * max_ratio
                 min_1 = int(K * min_1)


### PR DESCRIPTION
在MiMotion类中，调整了step_ratio的计算方式，将其乘以0.1以减小随机波动的影响，使结果更加稳定。